### PR TITLE
fix: AIチャット機能のバグ修正

### DIFF
--- a/nokoroa-backend/docker-compose.yml
+++ b/nokoroa-backend/docker-compose.yml
@@ -15,9 +15,10 @@ services:
       - FRONTEND_URL=http://localhost:3000
       - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
       - NODE_ENV=development
-      - AI_SERVICE_URL=http://host.docker.internal:8000
+      - AI_SERVICE_URL=http://ai:8000
     depends_on:
       - postgres
+      - ai
 
   postgres:
     image: postgres:16
@@ -30,6 +31,16 @@ services:
       POSTGRES_DB: nokoroa_db
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  ai:
+    container_name: nokoroa-ai
+    build:
+      context: ../nokoroa-ai
+      dockerfile: Dockerfile
+    ports:
+      - '8000:8000'
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
 
 volumes:
   postgres_data:

--- a/nokoroa-backend/docker-compose.yml
+++ b/nokoroa-backend/docker-compose.yml
@@ -12,9 +12,10 @@ services:
     command: npm run start:dev
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/nokoroa_db
-      - FRONTEND_URL=http://localhost:3000
+      - FRONTEND_URL=http://localhost:3003
       - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
       - NODE_ENV=development
+      - PORT=4000
       - AI_SERVICE_URL=http://ai:8000
     depends_on:
       - postgres

--- a/nokoroa-backend/src/app.module.ts
+++ b/nokoroa-backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { ChatModule } from './chat/chat.module';
 import { CommonModule } from './common/common.module';
 import { FavoritesModule } from './favorites/favorites.module';
 import { FollowsModule } from './follows/follows.module';
@@ -11,7 +12,6 @@ import { LoggerMiddleware } from './middleware/logger.middleware';
 import { PostsModule } from './posts/posts.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UsersModule } from './users/users.module';
-import { ChatModule } from './chat/chat.module';
 
 @Module({
   imports: [

--- a/nokoroa-backend/src/chat/chat.controller.ts
+++ b/nokoroa-backend/src/chat/chat.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, Post, Res } from '@nestjs/common';
+import { Body, Controller, Post, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { ChatService } from './chat.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ChatRequestDto } from './dto/chat-request.dto';
 import { RelatedPostsRequestDto } from './dto/related-posts-request.dto';
 import { SuggestionsRequestDto } from './dto/suggestions-request.dto';
 
 @Controller('chat')
+@UseGuards(JwtAuthGuard)
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 

--- a/nokoroa-backend/src/chat/chat.service.ts
+++ b/nokoroa-backend/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
 import { PostsService } from '../posts/posts.service';
@@ -8,6 +8,7 @@ import { SuggestionsRequestDto } from './dto/suggestions-request.dto';
 
 @Injectable()
 export class ChatService {
+  private readonly logger = new Logger(ChatService.name);
   private readonly aiServiceUrl: string;
 
   constructor(
@@ -81,8 +82,10 @@ export class ChatService {
           }),
         );
       }
-    } catch {
-      // noop
+    } catch (error) {
+      this.logger.warn(
+        `Failed to search related posts: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     const response = await fetch(`${this.aiServiceUrl}/api/chat/stream`, {
@@ -183,7 +186,10 @@ export class ChatService {
       });
 
       return { posts: fallbackResult.posts };
-    } catch {
+    } catch (error) {
+      this.logger.warn(
+        `Failed to get related posts: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return { posts: [] };
     }
   }

--- a/nokoroa-backend/src/chat/dto/chat-request.dto.ts
+++ b/nokoroa-backend/src/chat/dto/chat-request.dto.ts
@@ -1,5 +1,5 @@
-import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 class MessageDto {
   @IsString()

--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -42,6 +42,7 @@ const MotionPaper = motion.create(Paper);
 const MotionBox = motion.create(Box);
 
 const SUGGESTIONS = ['京都 2泊3日', '沖縄 おすすめ', '温泉旅行', '週末旅行'];
+const MAX_MESSAGES = 100;
 
 function TypingIndicator() {
   return (
@@ -126,10 +127,15 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
     setInput('');
     setDynamicSuggestions([]);
     const userMsgId = `user-${Date.now()}`;
-    setMessages((prev) => [
-      ...prev,
-      { role: 'user', content: userMessage, id: userMsgId },
-    ]);
+    setMessages((prev) => {
+      const updated = [
+        ...prev,
+        { role: 'user' as const, content: userMessage, id: userMsgId },
+      ];
+      return updated.length > MAX_MESSAGES
+        ? updated.slice(-MAX_MESSAGES)
+        : updated;
+    });
     setIsLoading(true);
 
     setTimeout(scrollToBottom, 100);
@@ -140,11 +146,17 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         content: msg.content,
       }));
 
+      const token = localStorage.getItem('token');
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
       const response = await fetch(`${API_URL}/api/chat/stream`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers,
         body: JSON.stringify({
           message: userMessage,
           history,
@@ -185,7 +197,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
           if (line.startsWith('data: ')) {
             const data = line.slice(6);
             if (data === '[DONE]') {
-              break;
+              continue;
             }
             if (data.startsWith('[ERROR]')) {
               throw new Error(data);
@@ -242,11 +254,17 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
 
       if (fullResponse) {
         try {
+          const suggestionsHeaders: Record<string, string> = {
+            'Content-Type': 'application/json',
+          };
+          if (token) {
+            suggestionsHeaders['Authorization'] = `Bearer ${token}`;
+          }
           const suggestionsRes = await fetch(
             `${API_URL}/api/chat/suggestions`,
             {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: suggestionsHeaders,
               body: JSON.stringify({
                 message: userMessage,
                 ai_response: fullResponse,

--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -146,7 +146,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         content: msg.content,
       }));
 
-      const token = localStorage.getItem('token');
+      const token = localStorage.getItem('jwt');
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
       };


### PR DESCRIPTION
## Summary
- チャットAPIにJWT認証ガード（`JwtAuthGuard`）を追加し、フロントエンドから`Authorization`ヘッダーを送信するよう修正
- `chat.service.ts`のcatch句にLogger追加でエラー原因の特定を容易に
- `docker-compose.yml`にnokoroa-aiサービスを追加（`AI_SERVICE_URL`を`http://ai:8000`に統一）
- フロントエンドのメッセージ履歴を100件上限に制限（メモリ効率改善）
- ストリーミング処理で`[DONE]`受信時に`break`→`continue`に変更し、バッファ残存データの欠損を防止

## Test plan
- [x] Backend単体テスト全pass（66 tests）
- [x] Frontend lint pass
- [ ] ブラウザでチャット機能の動作確認