### PR TITLE
feat: AIチャットのタイピングアニメーション

### DIFF
--- a/nokoroa-backend/src/chat/chat.service.ts
+++ b/nokoroa-backend/src/chat/chat.service.ts
@@ -84,7 +84,7 @@ export class ChatService {
       }
     } catch (error) {
       this.logger.warn(
-        `Failed to search related posts: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to search related posts: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
 
@@ -140,8 +140,8 @@ export class ChatService {
       return [];
     }
 
-    const data = await response.json();
-    return data.suggestions || [];
+    const data = (await response.json()) as { suggestions?: string[] };
+    return data.suggestions ?? [];
   }
 
   async getRelatedPosts(dto: RelatedPostsRequestDto) {
@@ -162,15 +162,19 @@ export class ChatService {
         return { posts: [] };
       }
 
-      const keywordsData = await keywordsRes.json();
+      const keywordsData = (await keywordsRes.json()) as {
+        keywords?: { location?: string };
+      };
       const keywords = keywordsData.keywords;
 
       if (!keywords) {
         return { posts: [] };
       }
 
+      const location = keywords.location ?? '';
+
       const result = await this.postsService.search({
-        location: keywords.location,
+        location,
         limit: 3,
         offset: 0,
       });
@@ -180,7 +184,7 @@ export class ChatService {
       }
 
       const fallbackResult = await this.postsService.search({
-        q: keywords.location,
+        q: location,
         limit: 3,
         offset: 0,
       });
@@ -188,7 +192,7 @@ export class ChatService {
       return { posts: fallbackResult.posts };
     } catch (error) {
       this.logger.warn(
-        `Failed to get related posts: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to get related posts: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
       return { posts: [] };
     }

--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -17,7 +17,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { PostData } from '@/types/post';
 
@@ -106,9 +106,51 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
   const [panelSize, setPanelSize] = useState<PanelSize>('medium');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const charQueueRef = useRef<string[]>([]);
+  const typingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  const startTyping = useCallback(() => {
+    if (typingTimerRef.current) return;
+    typingTimerRef.current = setInterval(() => {
+      if (charQueueRef.current.length === 0) {
+        if (typingTimerRef.current) {
+          clearInterval(typingTimerRef.current);
+          typingTimerRef.current = null;
+        }
+        return;
+      }
+      const char = charQueueRef.current.shift()!;
+      setMessages((prev) => {
+        const lastMessage = prev[prev.length - 1];
+        if (lastMessage?.role === 'assistant') {
+          return [
+            ...prev.slice(0, -1),
+            { ...lastMessage, content: lastMessage.content + char },
+          ];
+        }
+        return prev;
+      });
+      scrollToBottom();
+    }, 20);
+  }, [scrollToBottom]);
+
+  const stopTyping = useCallback(() => {
+    if (typingTimerRef.current) {
+      clearInterval(typingTimerRef.current);
+      typingTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (typingTimerRef.current) {
+        clearInterval(typingTimerRef.current);
+      }
+    };
   }, []);
 
   const handleToggleSize = () => {
@@ -180,6 +222,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         { role: 'assistant', content: '', id: assistantMsgId },
       ]);
       setIsLoading(false);
+      charQueueRef.current = [];
 
       let buffer = '';
       let fullResponse = '';
@@ -224,19 +267,27 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
             }
 
             fullResponse += data;
-            setMessages((prev) => {
-              const lastMessage = prev[prev.length - 1];
-              if (lastMessage?.role === 'assistant') {
-                return [
-                  ...prev.slice(0, -1),
-                  { ...lastMessage, content: lastMessage.content + data },
-                ];
-              }
-              return prev;
-            });
-            setTimeout(scrollToBottom, 10);
+            charQueueRef.current.push(...data.split(''));
+            startTyping();
           }
         }
+      }
+
+      // Flush remaining characters in queue
+      if (charQueueRef.current.length > 0) {
+        const remaining = charQueueRef.current.join('');
+        charQueueRef.current = [];
+        stopTyping();
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg?.role === 'assistant') {
+            return [
+              ...prev.slice(0, -1),
+              { ...lastMsg, content: lastMsg.content + remaining },
+            ];
+          }
+          return prev;
+        });
       }
 
       if (receivedRelatedPosts) {
@@ -280,6 +331,8 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         } catch {}
       }
     } catch {
+      stopTyping();
+      charQueueRef.current = [];
       setMessages((prev) => {
         const lastMessage = prev[prev.length - 1];
         if (lastMessage?.role === 'assistant' && lastMessage.content === '') {


### PR DESCRIPTION
## Summary
- ストリーミング受信したチャンクを1文字ずつ20ms間隔で表示するアニメーションを実装
- チャンクが一括で「ドカッ」と表示される問題を修正し、ChatGPTのような滑らかなタイピング表示に改善

## 実装
- `charQueueRef`でバッファリング、`setInterval(20ms)`で1文字ずつ描画
- ストリーム完了後は残りの文字を即座にフラッシュ
- エラー時・アンマウント時のクリーンアップ

## Test plan
- [x] Backend単体テスト全pass（66 tests）
- [x] Frontend lint pass
- [ ] ブラウザでタイピングアニメーション動作確認