### PR TITLE
feat: AI意味検索UI + INTERNAL_AI_TOKEN 認証必須化

### DIFF
--- a/nokoroa-ai/.env.example
+++ b/nokoroa-ai/.env.example
@@ -1,2 +1,3 @@
 GEMINI_API_KEY=your-gemini-api-key
 CORS_ORIGINS=http://localhost:3000,http://localhost:4000
+INTERNAL_AI_TOKEN=dev-internal-token

--- a/nokoroa-ai/app/config.py
+++ b/nokoroa-ai/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     gemini_api_key: str
     cors_origins: str = "http://localhost:3000,http://localhost:4000"
-    internal_api_key: str = ""
+    internal_ai_token: str = ""
 
     class Config:
         env_file = ".env"

--- a/nokoroa-ai/app/deps.py
+++ b/nokoroa-ai/app/deps.py
@@ -1,3 +1,5 @@
+import hmac
+
 from fastapi import Header, HTTPException
 
 from app.config import settings
@@ -12,5 +14,5 @@ def verify_internal_token(
             status_code=503,
             detail="INTERNAL_AI_TOKEN is not configured",
         )
-    if x_internal_token != expected:
+    if not hmac.compare_digest(expected, x_internal_token or ""):
         raise HTTPException(status_code=401, detail="invalid internal token")

--- a/nokoroa-ai/app/deps.py
+++ b/nokoroa-ai/app/deps.py
@@ -1,0 +1,16 @@
+from fastapi import Header, HTTPException
+
+from app.config import settings
+
+
+def verify_internal_token(
+    x_internal_token: str | None = Header(default=None),
+) -> None:
+    expected = settings.internal_ai_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="INTERNAL_AI_TOKEN is not configured",
+        )
+    if x_internal_token != expected:
+        raise HTTPException(status_code=401, detail="invalid internal token")

--- a/nokoroa-ai/app/main.py
+++ b/nokoroa-ai/app/main.py
@@ -1,7 +1,14 @@
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
 
 app = FastAPI(
     title="Nokoroa AI",

--- a/nokoroa-ai/app/routers/chat.py
+++ b/nokoroa-ai/app/routers/chat.py
@@ -130,6 +130,7 @@ async def get_suggestions(
         )
         return SuggestionsResponse(suggestions=result)
     except Exception:
+        logger.exception("suggestions generation failed")
         return SuggestionsResponse(suggestions=[])
 
 
@@ -145,4 +146,5 @@ async def get_related_keywords(
         )
         return RelatedKeywordsResponse(keywords=result)
     except Exception:
+        logger.exception("related keywords extraction failed")
         return RelatedKeywordsResponse(keywords=None)

--- a/nokoroa-ai/app/routers/chat.py
+++ b/nokoroa-ai/app/routers/chat.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -5,6 +7,8 @@ from pydantic import BaseModel
 from app.config import settings
 from app.deps import verify_internal_token
 from app.services.gemini_service import GeminiService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -52,8 +56,9 @@ async def chat(
             response=result["response"],
             grounding_metadata=result["grounding_metadata"],
         )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        logger.exception("chat failed")
+        raise HTTPException(status_code=500, detail="chat failed")
 
 
 @router.post("/stream")
@@ -81,8 +86,9 @@ async def chat_stream(
             ):
                 yield f"data: {chunk}\n\n"
             yield "data: [DONE]\n\n"
-        except Exception as e:
-            yield f"data: [ERROR] {str(e)}\n\n"
+        except Exception:
+            logger.exception("chat stream failed")
+            yield "data: [ERROR] chat stream failed\n\n"
 
     return StreamingResponse(
         generate(),

--- a/nokoroa-ai/app/routers/chat.py
+++ b/nokoroa-ai/app/routers/chat.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from app.main import settings
+from app.config import settings
+from app.deps import verify_internal_token
 from app.services.gemini_service import GeminiService
 
 router = APIRouter()
@@ -34,7 +35,10 @@ class ChatResponse(BaseModel):
 
 
 @router.post("/", response_model=ChatResponse)
-async def chat(request: ChatRequest):
+async def chat(
+    request: ChatRequest,
+    _: None = Depends(verify_internal_token),
+):
     try:
         history = None
         if request.history:
@@ -53,7 +57,10 @@ async def chat(request: ChatRequest):
 
 
 @router.post("/stream")
-async def chat_stream(request: ChatRequest):
+async def chat_stream(
+    request: ChatRequest,
+    _: None = Depends(verify_internal_token),
+):
     def generate():
         try:
             history = None
@@ -106,7 +113,10 @@ class RelatedKeywordsResponse(BaseModel):
 
 
 @router.post("/suggestions", response_model=SuggestionsResponse)
-async def get_suggestions(request: SuggestionsRequest):
+async def get_suggestions(
+    request: SuggestionsRequest,
+    _: None = Depends(verify_internal_token),
+):
     try:
         result = gemini_service.generate_suggestions(
             user_message=request.message,
@@ -118,7 +128,10 @@ async def get_suggestions(request: SuggestionsRequest):
 
 
 @router.post("/related-keywords", response_model=RelatedKeywordsResponse)
-async def get_related_keywords(request: RelatedKeywordsRequest):
+async def get_related_keywords(
+    request: RelatedKeywordsRequest,
+    _: None = Depends(verify_internal_token),
+):
     try:
         result = gemini_service.extract_search_keywords(
             user_message=request.message,

--- a/nokoroa-ai/app/routers/embeddings.py
+++ b/nokoroa-ai/app/routers/embeddings.py
@@ -2,10 +2,11 @@ import asyncio
 from functools import lru_cache
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from app.config import settings
+from app.deps import verify_internal_token
 from app.services.gemini_service import EMBEDDING_DIM, GeminiService
 
 router = APIRouter()
@@ -14,19 +15,6 @@ router = APIRouter()
 @lru_cache
 def get_gemini_service() -> GeminiService:
     return GeminiService(api_key=settings.gemini_api_key)
-
-
-def verify_internal_token(
-    x_internal_token: str | None = Header(default=None),
-) -> None:
-    expected = settings.internal_api_key
-    if not expected:
-        raise HTTPException(
-            status_code=503,
-            detail="INTERNAL_API_KEY is not configured",
-        )
-    if x_internal_token != expected:
-        raise HTTPException(status_code=401, detail="invalid internal token")
 
 
 TaskType = Literal[

--- a/nokoroa-ai/app/routers/embeddings.py
+++ b/nokoroa-ai/app/routers/embeddings.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from functools import lru_cache
 from typing import Literal
 
@@ -8,6 +9,8 @@ from pydantic import BaseModel, Field
 from app.config import settings
 from app.deps import verify_internal_token
 from app.services.gemini_service import EMBEDDING_DIM, GeminiService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -47,6 +50,7 @@ async def create_embedding(
             gemini.embed, request.text, request.task_type
         )
     except Exception:
+        logger.exception("embedding failed")
         raise HTTPException(status_code=502, detail="embedding failed")
 
     if len(vector) != EMBEDDING_DIM:

--- a/nokoroa-backend/.env.example
+++ b/nokoroa-backend/.env.example
@@ -12,6 +12,10 @@ GOOGLE_CALLBACK_URL="http://localhost:4000/auth/google/callback"
 # Frontend URL
 FRONTEND_URL="http://localhost:3000"
 
+# AI Service
+AI_SERVICE_URL="http://localhost:8000"
+INTERNAL_AI_TOKEN="dev-internal-token"
+
 # AWS (Optional)
 AWS_REGION="ap-northeast-1"
 AWS_ACCESS_KEY_ID="your-aws-access-key"

--- a/nokoroa-backend/docker-compose.yml
+++ b/nokoroa-backend/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - NODE_ENV=development
       - PORT=4000
       - AI_SERVICE_URL=http://ai:8000
+      - INTERNAL_AI_TOKEN=${INTERNAL_AI_TOKEN:-dev-internal-token}
     depends_on:
       - postgres
       - ai
@@ -42,6 +43,7 @@ services:
       - '8000:8000'
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - INTERNAL_AI_TOKEN=${INTERNAL_AI_TOKEN:-dev-internal-token}
 
 volumes:
   postgres_data:

--- a/nokoroa-backend/src/chat/chat.service.spec.ts
+++ b/nokoroa-backend/src/chat/chat.service.spec.ts
@@ -18,7 +18,11 @@ describe('ChatService', () => {
     searchSimilar: jest.fn(),
   };
   const mockConfig = {
-    get: jest.fn(() => 'http://test-ai:8000'),
+    get: jest.fn((key: string) => {
+      if (key === 'AI_SERVICE_URL') return 'http://test-ai:8000';
+      if (key === 'INTERNAL_AI_TOKEN') return 'test-token';
+      return undefined;
+    }),
   };
 
   beforeEach(async () => {
@@ -124,5 +128,29 @@ describe('ChatService', () => {
     await service.streamChat({ message: '札幌 ラーメン' }, makeRes());
 
     expect(mockPosts.search).toHaveBeenCalledTimes(2);
+  });
+
+  it('AI service への fetch に X-Internal-Token header を含める', async () => {
+    mockEmbeddings.searchSimilar.mockResolvedValue([]);
+    mockPosts.search.mockResolvedValue({
+      posts: [],
+      total: 0,
+      hasMore: false,
+    });
+    makeStreamFetch();
+
+    await service.streamChat({ message: 'hello' }, makeRes());
+
+    const calls = (
+      global.fetch as jest.Mock<
+        unknown,
+        [string, { headers: Record<string, string> }]
+      >
+    ).mock.calls;
+    const chatStreamCall = calls.find((c) => c[0].endsWith('/api/chat/stream'));
+    expect(chatStreamCall).toBeDefined();
+    const init = chatStreamCall[1];
+    expect(init.headers['X-Internal-Token']).toBe('test-token');
+    expect(init.headers['Content-Type']).toBe('application/json');
   });
 });

--- a/nokoroa-backend/src/chat/chat.service.ts
+++ b/nokoroa-backend/src/chat/chat.service.ts
@@ -111,7 +111,7 @@ export class ChatService {
         }));
       }
     } catch (error) {
-      this.logger.warn(
+      this.logger.error(
         `Failed to search related posts: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
@@ -175,6 +175,9 @@ export class ChatService {
     });
 
     if (!response.ok) {
+      this.logger.warn(
+        `AI suggestions responded ${response.status}; returning empty list`,
+      );
       return [];
     }
 
@@ -218,6 +221,9 @@ export class ChatService {
       );
 
       if (!keywordsRes.ok) {
+        this.logger.warn(
+          `AI related-keywords responded ${keywordsRes.status}; returning empty posts`,
+        );
         return { posts: [] };
       }
 
@@ -227,6 +233,9 @@ export class ChatService {
       const keywords = keywordsData.keywords;
 
       if (!keywords) {
+        this.logger.warn(
+          'AI related-keywords returned null; returning empty posts',
+        );
         return { posts: [] };
       }
 
@@ -250,7 +259,7 @@ export class ChatService {
 
       return { posts: fallbackResult.posts };
     } catch (error) {
-      this.logger.warn(
+      this.logger.error(
         `Failed to get related posts: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
       return { posts: [] };

--- a/nokoroa-backend/src/chat/chat.service.ts
+++ b/nokoroa-backend/src/chat/chat.service.ts
@@ -11,6 +11,7 @@ import { SuggestionsRequestDto } from './dto/suggestions-request.dto';
 export class ChatService {
   private readonly logger = new Logger(ChatService.name);
   private readonly aiServiceUrl: string;
+  private readonly internalToken: string;
 
   constructor(
     private configService: ConfigService,
@@ -20,6 +21,23 @@ export class ChatService {
     this.aiServiceUrl =
       this.configService.get<string>('AI_SERVICE_URL') ||
       'http://localhost:8000';
+    this.internalToken =
+      this.configService.get<string>('INTERNAL_AI_TOKEN') || '';
+    if (!this.internalToken) {
+      this.logger.warn(
+        'INTERNAL_AI_TOKEN is not configured; AI service will reject requests',
+      );
+    }
+  }
+
+  private aiHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.internalToken) {
+      headers['X-Internal-Token'] = this.internalToken;
+    }
+    return headers;
   }
 
   async streamChat(dto: ChatRequestDto, res: Response): Promise<void> {
@@ -102,7 +120,7 @@ export class ChatService {
     try {
       response = await fetch(`${this.aiServiceUrl}/api/chat/stream`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: this.aiHeaders(),
         body: JSON.stringify({
           message: dto.message,
           history: dto.history || [],
@@ -149,7 +167,7 @@ export class ChatService {
   async getSuggestions(dto: SuggestionsRequestDto): Promise<string[]> {
     const response = await fetch(`${this.aiServiceUrl}/api/chat/suggestions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.aiHeaders(),
       body: JSON.stringify({
         message: dto.message,
         ai_response: dto.ai_response,
@@ -191,7 +209,7 @@ export class ChatService {
         `${this.aiServiceUrl}/api/chat/related-keywords`,
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: this.aiHeaders(),
           body: JSON.stringify({
             message: dto.message,
             ai_response: dto.ai_response,

--- a/nokoroa-backend/src/embeddings/embeddings.service.spec.ts
+++ b/nokoroa-backend/src/embeddings/embeddings.service.spec.ts
@@ -13,9 +13,11 @@ describe('EmbeddingsService', () => {
   };
 
   const mockConfig = {
-    get: jest.fn((key: string) =>
-      key === 'AI_SERVICE_URL' ? 'http://test-ai:8000' : undefined,
-    ),
+    get: jest.fn((key: string) => {
+      if (key === 'AI_SERVICE_URL') return 'http://test-ai:8000';
+      if (key === 'INTERNAL_AI_TOKEN') return 'test-token';
+      return undefined;
+    }),
   };
 
   const mockEmbedding = Array.from({ length: 768 }, (_, i) => i / 768);
@@ -76,6 +78,21 @@ describe('EmbeddingsService', () => {
         service.generateForPost(1, 'タイトル', '本文'),
       ).resolves.toBeUndefined();
       expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('AI service に X-Internal-Token header を送る', async () => {
+      mockPrisma.$executeRawUnsafe.mockResolvedValue(1);
+
+      await service.generateForPost(7, 'タイトル', '本文');
+
+      const calls = (
+        global.fetch as jest.Mock<
+          unknown,
+          [string, { headers: Record<string, string> }]
+        >
+      ).mock.calls;
+      const init = calls[0][1];
+      expect(init.headers['X-Internal-Token']).toBe('test-token');
     });
   });
 

--- a/nokoroa-backend/src/embeddings/embeddings.service.ts
+++ b/nokoroa-backend/src/embeddings/embeddings.service.ts
@@ -46,7 +46,7 @@ export class EmbeddingsService {
     try {
       vector = await this.embed(text, 'RETRIEVAL_DOCUMENT');
     } catch (err) {
-      this.logger.warn(
+      this.logger.error(
         `Failed to embed post ${postId}: ${err instanceof Error ? err.message : 'unknown'}`,
       );
       return;
@@ -66,7 +66,7 @@ export class EmbeddingsService {
         literal,
       );
     } catch (err) {
-      this.logger.warn(
+      this.logger.error(
         `Failed to upsert embedding for post ${postId}: ${err instanceof Error ? err.message : 'unknown'}`,
       );
     }
@@ -104,7 +104,7 @@ export class EmbeddingsService {
     try {
       return await this.searchSimilarStrict(query, limit);
     } catch (err) {
-      this.logger.warn(
+      this.logger.error(
         `Vector search failed: ${err instanceof Error ? err.message : 'unknown'}`,
       );
       return [];

--- a/nokoroa-backend/src/embeddings/embeddings.service.ts
+++ b/nokoroa-backend/src/embeddings/embeddings.service.ts
@@ -26,6 +26,11 @@ export class EmbeddingsService {
       'http://localhost:8000';
     this.internalToken =
       this.configService.get<string>('INTERNAL_AI_TOKEN') || '';
+    if (!this.internalToken) {
+      this.logger.warn(
+        'INTERNAL_AI_TOKEN is not configured; AI service will reject requests',
+      );
+    }
   }
 
   async generateForPost(

--- a/nokoroa-backend/src/embeddings/embeddings.service.ts
+++ b/nokoroa-backend/src/embeddings/embeddings.service.ts
@@ -114,17 +114,20 @@ export class EmbeddingsService {
     }
   }
 
-  private async embed(text: string, taskType: string): Promise<number[]> {
+  private aiHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
     if (this.internalToken) {
       headers['X-Internal-Token'] = this.internalToken;
     }
+    return headers;
+  }
 
+  private async embed(text: string, taskType: string): Promise<number[]> {
     const res = await fetch(`${this.aiServiceUrl}/api/embeddings/`, {
       method: 'POST',
-      headers,
+      headers: this.aiHeaders(),
       body: JSON.stringify({ text, task_type: taskType }),
       signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
     });

--- a/nokoroa-backend/src/embeddings/embeddings.service.ts
+++ b/nokoroa-backend/src/embeddings/embeddings.service.ts
@@ -72,40 +72,37 @@ export class EmbeddingsService {
     }
   }
 
-  async searchSimilar(query: string, limit = 5): Promise<SimilarPostHit[]> {
+  async searchSimilarStrict(
+    query: string,
+    limit = 5,
+  ): Promise<SimilarPostHit[]> {
     const trimmed = query?.trim() ?? '';
     if (!trimmed) return [];
     const text = trimmed.slice(0, MAX_TEXT_LEN);
 
-    let vector: number[];
-    try {
-      vector = await this.embed(text, 'RETRIEVAL_QUERY');
-    } catch (err) {
-      this.logger.warn(
-        `Failed to embed query: ${err instanceof Error ? err.message : 'unknown'}`,
-      );
-      return [];
-    }
-
+    const vector = await this.embed(text, 'RETRIEVAL_QUERY');
     const literal = this.vectorLiteral(vector);
+    const rows = await this.prisma.$queryRawUnsafe<
+      { postId: number; distance: number }[]
+    >(
+      `SELECT pe."postId", (pe.embedding <=> $1::vector)::float8 AS distance
+       FROM post_embedding pe
+       JOIN post p ON p.id = pe."postId"
+       WHERE p."isPublic" = true
+       ORDER BY pe.embedding <=> $1::vector
+       LIMIT $2`,
+      literal,
+      limit,
+    );
+    return rows.map((r) => ({
+      postId: Number(r.postId),
+      distance: Number(r.distance),
+    }));
+  }
 
+  async searchSimilar(query: string, limit = 5): Promise<SimilarPostHit[]> {
     try {
-      const rows = await this.prisma.$queryRawUnsafe<
-        { postId: number; distance: number }[]
-      >(
-        `SELECT pe."postId", (pe.embedding <=> $1::vector)::float8 AS distance
-         FROM post_embedding pe
-         JOIN post p ON p.id = pe."postId"
-         WHERE p."isPublic" = true
-         ORDER BY pe.embedding <=> $1::vector
-         LIMIT $2`,
-        literal,
-        limit,
-      );
-      return rows.map((r) => ({
-        postId: Number(r.postId),
-        distance: Number(r.distance),
-      }));
+      return await this.searchSimilarStrict(query, limit);
     } catch (err) {
       this.logger.warn(
         `Vector search failed: ${err instanceof Error ? err.message : 'unknown'}`,

--- a/nokoroa-backend/src/posts/dto/search-posts-semantic.dto.ts
+++ b/nokoroa-backend/src/posts/dto/search-posts-semantic.dto.ts
@@ -1,0 +1,34 @@
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class SearchPostsSemanticDto {
+  @ApiProperty({
+    description: '意味検索クエリ（自然文）',
+    example: '紅葉と温泉が楽しめる秋の旅行',
+  })
+  @IsString()
+  @IsNotEmpty()
+  q!: string;
+
+  @ApiPropertyOptional({
+    description: '取得件数（1〜20）',
+    example: 10,
+    minimum: 1,
+    maximum: 20,
+    default: 10,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(20)
+  @Type(() => Number)
+  limit?: number = 10;
+}

--- a/nokoroa-backend/src/posts/dto/search-posts-semantic.dto.ts
+++ b/nokoroa-backend/src/posts/dto/search-posts-semantic.dto.ts
@@ -1,12 +1,12 @@
 import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
-  IsNotEmpty,
   IsNumber,
   IsOptional,
   IsString,
   Max,
   Min,
+  MinLength,
 } from 'class-validator';
 
 export class SearchPostsSemanticDto {
@@ -15,7 +15,10 @@ export class SearchPostsSemanticDto {
     example: '紅葉と温泉が楽しめる秋の旅行',
   })
   @IsString()
-  @IsNotEmpty()
+  @Transform(({ value }): string =>
+    typeof value === 'string' ? value.trim() : '',
+  )
+  @MinLength(1)
   q!: string;
 
   @ApiPropertyOptional({

--- a/nokoroa-backend/src/posts/posts.controller.ts
+++ b/nokoroa-backend/src/posts/posts.controller.ts
@@ -152,12 +152,15 @@ export class PostsController {
   }
 
   @Get('search/semantic')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: '意味検索（ベクトル検索）',
     description:
-      '自然文クエリを Gemini で埋め込み、pgvector の cosine 類似度で投稿を検索します',
+      '自然文クエリを Gemini で埋め込み、pgvector の cosine 類似度で投稿を検索します（要ログイン: 課金 API のため）',
   })
   @ApiResponse({ status: 200, description: '検索成功' })
+  @ApiResponse({ status: 401, description: '認証エラー' })
   searchSemantic(@Query() dto: SearchPostsSemanticDto) {
     return this.postsService.searchSemantic(dto);
   }

--- a/nokoroa-backend/src/posts/posts.controller.ts
+++ b/nokoroa-backend/src/posts/posts.controller.ts
@@ -30,6 +30,7 @@ import { memoryStorage } from 'multer';
 import { S3Service } from '../common/s3.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { SearchPostsByLocationDto } from './dto/search-posts-by-location.dto';
+import { SearchPostsSemanticDto } from './dto/search-posts-semantic.dto';
 import { SearchPostsDto } from './dto/search-posts.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { PostsService } from './posts.service';
@@ -148,6 +149,17 @@ export class PostsController {
   @ApiResponse({ status: 200, description: '検索成功' })
   search(@Query() searchPostsDto: SearchPostsDto) {
     return this.postsService.search(searchPostsDto);
+  }
+
+  @Get('search/semantic')
+  @ApiOperation({
+    summary: '意味検索（ベクトル検索）',
+    description:
+      '自然文クエリを Gemini で埋め込み、pgvector の cosine 類似度で投稿を検索します',
+  })
+  @ApiResponse({ status: 200, description: '検索成功' })
+  searchSemantic(@Query() dto: SearchPostsSemanticDto) {
+    return this.postsService.searchSemantic(dto);
   }
 
   @Get('search-by-location')

--- a/nokoroa-backend/src/posts/posts.service.spec.ts
+++ b/nokoroa-backend/src/posts/posts.service.spec.ts
@@ -72,6 +72,7 @@ describe('PostsService', () => {
   const mockEmbeddingsService = {
     generateForPost: jest.fn().mockResolvedValue(undefined),
     searchSimilar: jest.fn().mockResolvedValue([]),
+    searchSimilarStrict: jest.fn().mockResolvedValue([]),
   };
 
   beforeEach(async () => {
@@ -304,7 +305,7 @@ describe('PostsService', () => {
 
   describe('searchSemantic', () => {
     it('ヒットIDを類似度付きで返す（hit順を保つ）', async () => {
-      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([
+      mockEmbeddingsService.searchSimilarStrict.mockResolvedValueOnce([
         { postId: 2, distance: 0.1 },
         { postId: 1, distance: 0.4 },
       ]);
@@ -318,7 +319,7 @@ describe('PostsService', () => {
         limit: 5,
       });
 
-      expect(mockEmbeddingsService.searchSimilar).toHaveBeenCalledWith(
+      expect(mockEmbeddingsService.searchSimilarStrict).toHaveBeenCalledWith(
         '紅葉と温泉',
         5,
       );
@@ -327,10 +328,22 @@ describe('PostsService', () => {
       expect(result.posts[1].similarity).toBeCloseTo(0.6);
       expect(result.total).toBe(2);
       expect(result.hasMore).toBe(false);
+      expect(result.aiAvailable).toBe(true);
+    });
+
+    it('AI service エラー時は aiAvailable=false で空結果', async () => {
+      mockEmbeddingsService.searchSimilarStrict.mockRejectedValueOnce(
+        new Error('embedding service responded 503'),
+      );
+
+      const result = await service.searchSemantic({ q: 'q', limit: 5 });
+
+      expect(result.posts).toEqual([]);
+      expect(result.aiAvailable).toBe(false);
     });
 
     it('ヒット0件なら空結果', async () => {
-      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([]);
+      mockEmbeddingsService.searchSimilarStrict.mockResolvedValueOnce([]);
 
       const result = await service.searchSemantic({ q: 'なし', limit: 5 });
 
@@ -340,7 +353,7 @@ describe('PostsService', () => {
     });
 
     it('distance が 1 を超えても similarity は 0 にクランプする', async () => {
-      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([
+      mockEmbeddingsService.searchSimilarStrict.mockResolvedValueOnce([
         { postId: 1, distance: 1.5 },
       ]);
       mockPrismaService.post.findMany.mockResolvedValue([

--- a/nokoroa-backend/src/posts/posts.service.spec.ts
+++ b/nokoroa-backend/src/posts/posts.service.spec.ts
@@ -302,6 +302,57 @@ describe('PostsService', () => {
     });
   });
 
+  describe('searchSemantic', () => {
+    it('ヒットIDを類似度付きで返す（hit順を保つ）', async () => {
+      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([
+        { postId: 2, distance: 0.1 },
+        { postId: 1, distance: 0.4 },
+      ]);
+      mockPrismaService.post.findMany.mockResolvedValue([
+        { ...mockPost, id: 1 },
+        { ...mockPost, id: 2 },
+      ]);
+
+      const result = await service.searchSemantic({
+        q: '紅葉と温泉',
+        limit: 5,
+      });
+
+      expect(mockEmbeddingsService.searchSimilar).toHaveBeenCalledWith(
+        '紅葉と温泉',
+        5,
+      );
+      expect(result.posts.map((p) => p.id)).toEqual([2, 1]);
+      expect(result.posts[0].similarity).toBeCloseTo(0.9);
+      expect(result.posts[1].similarity).toBeCloseTo(0.6);
+      expect(result.total).toBe(2);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('ヒット0件なら空結果', async () => {
+      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([]);
+
+      const result = await service.searchSemantic({ q: 'なし', limit: 5 });
+
+      expect(result.posts).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(mockPrismaService.post.findMany).not.toHaveBeenCalled();
+    });
+
+    it('distance が 1 を超えても similarity は 0 にクランプする', async () => {
+      mockEmbeddingsService.searchSimilar.mockResolvedValueOnce([
+        { postId: 1, distance: 1.5 },
+      ]);
+      mockPrismaService.post.findMany.mockResolvedValue([
+        { ...mockPost, id: 1 },
+      ]);
+
+      const result = await service.searchSemantic({ q: 'q', limit: 5 });
+
+      expect(result.posts[0].similarity).toBe(0);
+    });
+  });
+
   describe('getTags', () => {
     it('タグ一覧を取得できる', async () => {
       mockPrismaService.tag = {

--- a/nokoroa-backend/src/posts/posts.service.ts
+++ b/nokoroa-backend/src/posts/posts.service.ts
@@ -282,7 +282,7 @@ export class PostsService {
     try {
       hits = await this.embeddingsService.searchSimilarStrict(q, limit);
     } catch (err) {
-      this.logger.warn(
+      this.logger.error(
         `Semantic search AI unavailable: ${err instanceof Error ? err.message : 'unknown'}`,
       );
       return { posts: [], total: 0, hasMore: false, aiAvailable: false };

--- a/nokoroa-backend/src/posts/posts.service.ts
+++ b/nokoroa-backend/src/posts/posts.service.ts
@@ -9,6 +9,7 @@ import { EmbeddingsService } from '../embeddings/embeddings.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { SearchPostsByLocationDto } from './dto/search-posts-by-location.dto';
+import { SearchPostsSemanticDto } from './dto/search-posts-semantic.dto';
 import { SearchPostsDto } from './dto/search-posts.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 
@@ -269,6 +270,34 @@ export class PostsService {
       include: postInclude,
     });
     return (posts as PostWithRelations[]).map(formatPost);
+  }
+
+  async searchSemantic(dto: SearchPostsSemanticDto) {
+    const { q, limit = 10 } = dto;
+
+    const hits = await this.embeddingsService.searchSimilar(q, limit);
+    if (hits.length === 0) {
+      return { posts: [], total: 0, hasMore: false };
+    }
+
+    const ids = hits.map((h) => h.postId);
+    const hydrated = await this.findManyByIds(ids);
+    const byId = new Map(hydrated.map((p) => [p.id, p]));
+
+    const ranked = hits
+      .map((hit) => {
+        const post = byId.get(hit.postId);
+        if (!post) return null;
+        const similarity = Math.max(0, 1 - hit.distance);
+        return { ...post, similarity };
+      })
+      .filter((p): p is NonNullable<typeof p> => p !== null);
+
+    return {
+      posts: ranked,
+      total: ranked.length,
+      hasMore: false,
+    };
   }
 
   async findOne(id: number) {

--- a/nokoroa-backend/src/posts/posts.service.ts
+++ b/nokoroa-backend/src/posts/posts.service.ts
@@ -5,7 +5,10 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { EmbeddingsService } from '../embeddings/embeddings.service';
+import {
+  EmbeddingsService,
+  SimilarPostHit,
+} from '../embeddings/embeddings.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { SearchPostsByLocationDto } from './dto/search-posts-by-location.dto';
@@ -275,9 +278,18 @@ export class PostsService {
   async searchSemantic(dto: SearchPostsSemanticDto) {
     const { q, limit = 10 } = dto;
 
-    const hits = await this.embeddingsService.searchSimilar(q, limit);
+    let hits: SimilarPostHit[];
+    try {
+      hits = await this.embeddingsService.searchSimilarStrict(q, limit);
+    } catch (err) {
+      this.logger.warn(
+        `Semantic search AI unavailable: ${err instanceof Error ? err.message : 'unknown'}`,
+      );
+      return { posts: [], total: 0, hasMore: false, aiAvailable: false };
+    }
+
     if (hits.length === 0) {
-      return { posts: [], total: 0, hasMore: false };
+      return { posts: [], total: 0, hasMore: false, aiAvailable: true };
     }
 
     const ids = hits.map((h) => h.postId);
@@ -297,6 +309,7 @@ export class PostsService {
       posts: ranked,
       total: ranked.length,
       hasMore: false,
+      aiAvailable: true,
     };
   }
 

--- a/nokoroa-frontend/src/app/search/page.tsx
+++ b/nokoroa-frontend/src/app/search/page.tsx
@@ -24,6 +24,7 @@ export default function SearchPage() {
     if (tagParam) {
       const initialFilters: SearchFilters = {
         tags: [tagParam],
+        mode: 'keyword',
         limit: 10,
         offset: 0,
       };
@@ -90,6 +91,7 @@ export default function SearchPage() {
         hasMore={hasMore}
         isLoadingMore={isLoadingMore}
         onLoadMore={handleLoadMore}
+        mode={filters.mode}
       />
     </Container>
   );

--- a/nokoroa-frontend/src/components/search/SearchForm.tsx
+++ b/nokoroa-frontend/src/components/search/SearchForm.tsx
@@ -2,6 +2,7 @@
 
 import {
   Add as AddIcon,
+  AutoAwesome as AutoAwesomeIcon,
   Clear as ClearIcon,
   ExpandMore as ExpandMoreIcon,
   History as HistoryIcon,
@@ -23,6 +24,9 @@ import {
   ListItemText,
   Paper,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
@@ -32,7 +36,7 @@ import { useSearchSuggestions } from '@/hooks/useSearchSuggestions';
 import { useTags } from '@/hooks/useTags';
 import { getTagColor } from '@/utils/tagColors';
 
-import { SearchFilters } from '../../types/search';
+import { SearchFilters, SearchMode } from '../../types/search';
 
 interface SearchFormProps {
   onSearch: (filters: SearchFilters) => void;
@@ -47,6 +51,10 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(
     !!(initialFilters?.tags?.length || initialFilters?.location),
   );
+  const [mode, setMode] = useState<SearchMode>(
+    initialFilters?.mode ?? 'keyword',
+  );
+  const isSemantic = mode === 'semantic';
 
   // タグ候補を取得
   const { tags: availableTags } = useTags();
@@ -133,15 +141,30 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
       addLocationToHistory(location.trim());
     }
 
-    const filters: SearchFilters = {
-      q: query.trim() || undefined,
-      tags: tags.length > 0 ? tags : undefined,
-      location: location.trim() || undefined,
-      limit: 10,
-      offset: 0,
-    };
+    const filters: SearchFilters = isSemantic
+      ? {
+          q: query.trim() || undefined,
+          mode: 'semantic',
+          limit: 10,
+          offset: 0,
+        }
+      : {
+          q: query.trim() || undefined,
+          tags: tags.length > 0 ? tags : undefined,
+          location: location.trim() || undefined,
+          mode: 'keyword',
+          limit: 10,
+          offset: 0,
+        };
 
     onSearch(filters);
+  };
+
+  const handleModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newMode: SearchMode | null,
+  ) => {
+    if (newMode) setMode(newMode);
   };
 
   const handleAddTag = (value: string) => {
@@ -167,6 +190,26 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
   return (
     <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
       <form onSubmit={handleSubmit}>
+        <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-start' }}>
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={handleModeChange}
+            size="small"
+            aria-label="検索モード"
+          >
+            <ToggleButton value="keyword" aria-label="キーワード検索">
+              <SearchIcon fontSize="small" sx={{ mr: 0.5 }} />
+              キーワード
+            </ToggleButton>
+            <Tooltip title="自然文クエリを Gemini で埋め込み、意味の近い投稿を検索します">
+              <ToggleButton value="semantic" aria-label="AI意味検索">
+                <AutoAwesomeIcon fontSize="small" sx={{ mr: 0.5 }} />
+                AI意味検索
+              </ToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
+        </Box>
         <Box sx={{ mb: 3 }}>
           <Autocomplete
             freeSolo
@@ -220,18 +263,22 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
               <TextField
                 {...params}
                 fullWidth
-                label="キーワード検索"
-                placeholder="タイトル、コンテンツ、著者名で検索..."
+                label={isSemantic ? 'AI意味検索' : 'キーワード検索'}
+                placeholder={
+                  isSemantic
+                    ? '「紅葉と温泉が楽しめる秋の旅行」のように自然文でどうぞ'
+                    : 'タイトル、コンテンツ、著者名で検索...'
+                }
                 InputProps={{
                   ...params.InputProps,
                   startAdornment: (
                     <InputAdornment position="start">
-                      <SearchIcon />
+                      {isSemantic ? <AutoAwesomeIcon /> : <SearchIcon />}
                     </InputAdornment>
                   ),
                   endAdornment: (
                     <>
-                      {keywordLoading && (
+                      {keywordLoading && !isSemantic && (
                         <CircularProgress color="inherit" size={20} />
                       )}
                       {params.InputProps.endAdornment}
@@ -240,13 +287,14 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
                 }}
               />
             )}
-            loading={keywordLoading}
+            loading={keywordLoading && !isSemantic}
           />
         </Box>
 
         <Accordion
-          expanded={isAdvancedOpen}
-          onChange={() => setIsAdvancedOpen(!isAdvancedOpen)}
+          expanded={!isSemantic && isAdvancedOpen}
+          onChange={() => !isSemantic && setIsAdvancedOpen(!isAdvancedOpen)}
+          disabled={isSemantic}
         >
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography>詳細検索</Typography>

--- a/nokoroa-frontend/src/components/search/SearchForm.tsx
+++ b/nokoroa-frontend/src/components/search/SearchForm.tsx
@@ -133,11 +133,10 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    // 検索履歴に追加
-    if (query.trim()) {
+    if (!isSemantic && query.trim()) {
       addKeywordToHistory(query.trim());
     }
-    if (location.trim()) {
+    if (!isSemantic && location.trim()) {
       addLocationToHistory(location.trim());
     }
 

--- a/nokoroa-frontend/src/components/search/SearchForm.tsx
+++ b/nokoroa-frontend/src/components/search/SearchForm.tsx
@@ -164,7 +164,14 @@ export const SearchForm = ({ onSearch, initialFilters }: SearchFormProps) => {
     _event: React.MouseEvent<HTMLElement>,
     newMode: SearchMode | null,
   ) => {
-    if (newMode) setMode(newMode);
+    if (!newMode || newMode === mode) return;
+    setMode(newMode);
+    setQuery('');
+    if (newMode === 'semantic') {
+      setTags([]);
+      setLocation('');
+      setTagInputValue('');
+    }
   };
 
   const handleAddTag = (value: string) => {

--- a/nokoroa-frontend/src/components/search/SearchResults.tsx
+++ b/nokoroa-frontend/src/components/search/SearchResults.tsx
@@ -72,14 +72,16 @@ const SearchPostCard = ({ post }: { post: Post }) => {
           {typeof post.similarity === 'number' && (
             <Chip
               icon={<AutoAwesomeIcon fontSize="small" />}
-              label={`類似度 ${Math.max(1, Math.round(post.similarity * 100))}%`}
+              label={`類似度 ${Math.round(post.similarity * 100)}%`}
               size="small"
-              aria-label={`類似度 ${Math.round(post.similarity * 100)} パーセント`}
               sx={{
                 position: 'absolute',
                 top: 8,
                 right: 8,
-                bgcolor: 'rgba(255, 152, 0, 0.95)',
+                bgcolor:
+                  post.similarity >= 0.3
+                    ? 'rgba(255, 152, 0, 0.95)'
+                    : 'rgba(120, 120, 120, 0.85)',
                 color: '#fff',
                 fontWeight: 600,
               }}
@@ -235,6 +237,14 @@ export const SearchResults = ({
           検索条件を入力して投稿を検索してみてください。
         </Typography>
       </Box>
+    );
+  }
+
+  if (mode === 'semantic' && data?.aiAvailable === false) {
+    return (
+      <Alert severity="warning" sx={{ mb: 2 }}>
+        AI意味検索が一時的に利用できません。少し時間をおいて再度お試しください。
+      </Alert>
     );
   }
 

--- a/nokoroa-frontend/src/components/search/SearchResults.tsx
+++ b/nokoroa-frontend/src/components/search/SearchResults.tsx
@@ -22,6 +22,7 @@ import { formatDistanceToNow } from '@/utils/dateFormat';
 import { getTagColor } from '@/utils/tagColors';
 
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import { SearchFetchError } from '../../hooks/useSearchPosts';
 import { Post, SearchMode, SearchResponse } from '../../types/search';
 import BookmarkButton from '../bookmarks/BookmarkButton';
 
@@ -223,6 +224,17 @@ export const SearchResults = ({
   }
 
   if (error) {
+    if (
+      mode === 'semantic' &&
+      error instanceof SearchFetchError &&
+      error.status === 401
+    ) {
+      return (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          AI意味検索を利用するにはログインが必要です。
+        </Alert>
+      );
+    }
     return (
       <Alert severity="error" sx={{ mb: 2 }}>
         検索中にエラーが発生しました。もう一度お試しください。

--- a/nokoroa-frontend/src/components/search/SearchResults.tsx
+++ b/nokoroa-frontend/src/components/search/SearchResults.tsx
@@ -22,7 +22,7 @@ import { formatDistanceToNow } from '@/utils/dateFormat';
 import { getTagColor } from '@/utils/tagColors';
 
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
-import { Post, SearchResponse } from '../../types/search';
+import { Post, SearchMode, SearchResponse } from '../../types/search';
 import BookmarkButton from '../bookmarks/BookmarkButton';
 
 interface SearchResultsProps {
@@ -33,6 +33,7 @@ interface SearchResultsProps {
   hasMore: boolean;
   isLoadingMore: boolean;
   onLoadMore: () => void;
+  mode?: SearchMode;
 }
 
 const SearchPostCard = ({ post }: { post: Post }) => {
@@ -71,8 +72,9 @@ const SearchPostCard = ({ post }: { post: Post }) => {
           {typeof post.similarity === 'number' && (
             <Chip
               icon={<AutoAwesomeIcon fontSize="small" />}
-              label={`類似度 ${Math.round(post.similarity * 100)}%`}
+              label={`類似度 ${Math.max(1, Math.round(post.similarity * 100))}%`}
               size="small"
+              aria-label={`類似度 ${Math.round(post.similarity * 100)} パーセント`}
               sx={{
                 position: 'absolute',
                 top: 8,
@@ -203,6 +205,7 @@ export const SearchResults = ({
   hasMore,
   isLoadingMore,
   onLoadMore,
+  mode,
 }: SearchResultsProps) => {
   const { lastElementRef } = useInfiniteScroll({
     hasMore,
@@ -254,6 +257,11 @@ export const SearchResults = ({
         <Typography variant="body2" color="text.secondary">
           {data.total}件の投稿が見つかりました
         </Typography>
+        {mode === 'semantic' && (
+          <Alert severity="info" sx={{ mt: 2 }} icon={false}>
+            AI意味検索は類似度が高い上位 {data.posts.length} 件のみ表示します
+          </Alert>
+        )}
       </Box>
 
       <Divider sx={{ mb: 3 }} />

--- a/nokoroa-frontend/src/components/search/SearchResults.tsx
+++ b/nokoroa-frontend/src/components/search/SearchResults.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import {
   Alert,
@@ -60,12 +61,29 @@ const SearchPostCard = ({ post }: { post: Post }) => {
           },
         }}
       >
-        <CardMedia
-          component="img"
-          height="280"
-          image={post.imageUrl || '/top.jpg'}
-          alt={post.title}
-        />
+        <Box sx={{ position: 'relative' }}>
+          <CardMedia
+            component="img"
+            height="280"
+            image={post.imageUrl || '/top.jpg'}
+            alt={post.title}
+          />
+          {typeof post.similarity === 'number' && (
+            <Chip
+              icon={<AutoAwesomeIcon fontSize="small" />}
+              label={`類似度 ${Math.round(post.similarity * 100)}%`}
+              size="small"
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                bgcolor: 'rgba(255, 152, 0, 0.95)',
+                color: '#fff',
+                fontWeight: 600,
+              }}
+            />
+          )}
+        </Box>
         <CardContent sx={{ flexGrow: 1, bgcolor: 'background.paper' }}>
           <Stack spacing={2}>
             <Box>

--- a/nokoroa-frontend/src/hooks/useSearchPosts.ts
+++ b/nokoroa-frontend/src/hooks/useSearchPosts.ts
@@ -17,6 +17,12 @@ const fetcher = async (url: string): Promise<SearchResponse> => {
 const buildSearchUrl = (filters: SearchFilters): string => {
   const searchParams = new URLSearchParams();
 
+  if (filters.mode === 'semantic') {
+    if (filters.q) searchParams.append('q', filters.q);
+    if (filters.limit) searchParams.append('limit', filters.limit.toString());
+    return `${API_BASE_URL}/posts/search/semantic?${searchParams.toString()}`;
+  }
+
   if (filters.q) searchParams.append('q', filters.q);
   if (filters.tags && filters.tags.length > 0) {
     searchParams.append('tags', filters.tags.join(','));
@@ -34,7 +40,10 @@ export const useSearchPosts = (
   filters: SearchFilters,
   shouldFetch: boolean = true,
 ) => {
-  const url = shouldFetch ? buildSearchUrl(filters) : null;
+  const isSemanticWithoutQuery =
+    filters.mode === 'semantic' && !filters.q?.trim();
+  const url =
+    shouldFetch && !isSemanticWithoutQuery ? buildSearchUrl(filters) : null;
 
   return useSWR<SearchResponse>(url, fetcher, {
     revalidateOnFocus: false,

--- a/nokoroa-frontend/src/hooks/useSearchPosts.ts
+++ b/nokoroa-frontend/src/hooks/useSearchPosts.ts
@@ -7,7 +7,11 @@ import { SearchFilters, SearchResponse } from '../types/search';
 const API_BASE_URL = API_CONFIG.BASE_URL || 'http://localhost:4000';
 
 const fetcher = async (url: string): Promise<SearchResponse> => {
-  const response = await fetch(url);
+  const isSemantic = url.includes('/posts/search/semantic');
+  const headers: Record<string, string> = isSemantic
+    ? API_CONFIG.getAuthHeaders()
+    : {};
+  const response = await fetch(url, { headers });
   if (!response.ok) {
     throw new Error('Failed to fetch search results');
   }

--- a/nokoroa-frontend/src/hooks/useSearchPosts.ts
+++ b/nokoroa-frontend/src/hooks/useSearchPosts.ts
@@ -6,6 +6,15 @@ import { SearchFilters, SearchResponse } from '../types/search';
 
 const API_BASE_URL = API_CONFIG.BASE_URL || 'http://localhost:4000';
 
+export class SearchFetchError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'SearchFetchError';
+    this.status = status;
+  }
+}
+
 const fetcher = async (url: string): Promise<SearchResponse> => {
   const isSemantic = url.includes('/posts/search/semantic');
   const headers: Record<string, string> = isSemantic
@@ -13,7 +22,10 @@ const fetcher = async (url: string): Promise<SearchResponse> => {
     : {};
   const response = await fetch(url, { headers });
   if (!response.ok) {
-    throw new Error('Failed to fetch search results');
+    throw new SearchFetchError(
+      response.status,
+      `Failed to fetch search results (${response.status})`,
+    );
   }
   return response.json();
 };

--- a/nokoroa-frontend/src/lib/apiConfig.ts
+++ b/nokoroa-frontend/src/lib/apiConfig.ts
@@ -49,7 +49,8 @@ export const API_CONFIG = {
   },
 
   getAuthHeaders: () => {
-    const token = localStorage.getItem('jwt');
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
     return {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -57,7 +58,8 @@ export const API_CONFIG = {
   },
 
   getFormDataAuthHeaders: () => {
-    const token = localStorage.getItem('jwt');
+    const token =
+      typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
     return {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     };

--- a/nokoroa-frontend/src/types/post.ts
+++ b/nokoroa-frontend/src/types/post.ts
@@ -45,6 +45,7 @@ export interface PostData {
   updatedAt: string;
   author: PostAuthor;
   distance?: number; // 地理的検索時の距離
+  similarity?: number; // 意味検索時のコサイン類似度（0-1）
   _count?: PostCount;
   // 互換性のため一時的に残す
   favoritesCount?: number;

--- a/nokoroa-frontend/src/types/search.ts
+++ b/nokoroa-frontend/src/types/search.ts
@@ -1,5 +1,7 @@
 import { PostData } from './post';
 
+export type SearchMode = 'keyword' | 'semantic';
+
 export interface SearchFilters {
   q?: string;
   tags?: string[];
@@ -7,6 +9,7 @@ export interface SearchFilters {
   authorId?: number;
   limit?: number;
   offset?: number;
+  mode?: SearchMode;
 }
 
 export type Post = PostData;

--- a/nokoroa-frontend/src/types/search.ts
+++ b/nokoroa-frontend/src/types/search.ts
@@ -18,4 +18,5 @@ export interface SearchResponse {
   posts: Post[];
   total: number;
   hasMore: boolean;
+  aiAvailable?: boolean;
 }

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -231,7 +231,7 @@ resource "aws_ecs_task_definition" "backend" {
           valueFrom = var.gemini_api_key_secret_arn
         },
         {
-          name      = "INTERNAL_API_KEY"
+          name      = "INTERNAL_AI_TOKEN"
           valueFrom = var.internal_api_key_secret_arn
         }
       ]


### PR DESCRIPTION
## Summary

既存の pgvector + Gemini RAG 基盤に対し、(1) AI サービス間通信のセキュリティ強化 と (2) ユーザーが意味検索を利用できる UI 入口 を追加。

### セキュリティ
- `nokoroa-ai` の全エンドポイント (embeddings + chat の 4 系統) で `X-Internal-Token` ヘッダを必須化（未設定なら 503 / 不一致なら 401）。
- 環境変数名を `INTERNAL_API_KEY` → `INTERNAL_AI_TOKEN` に統一（backend / ai / terraform / .env.example / docker-compose を同名で揃え、運用ミスを防ぐ）。
- backend の `chat.service.ts` も AI 呼び出し時に token ヘッダを付与（既存 `embeddings.service.ts` と同じ方針）。

### ベクトル検索エンドポイント
- `GET /posts/search/semantic?q=<自然文>&limit=<1-20>` 追加。Gemini で query を embed → pgvector cosine 距離でランキング → 投稿を hydrate して `similarity` (0-1) 付きで返却。
- ヒット順を保持（pgvector の `<=>` 距離順）。

### フロントエンド
- `SearchForm` に ToggleButton「キーワード / AI意味検索」追加。AI モード時は plainspoken な自然文 placeholder に切替、詳細検索（タグ・場所）は無効化。
- `SearchResults` 各カード右上に `類似度 NN%` Chip を表示（semantic 時のみ）。
- `useSearchPosts` hook を mode 分岐に拡張（既存キーワード検索は維持）。

### テスト
- `embeddings.service.spec.ts`: `X-Internal-Token` ヘッダ送信を検証
- `chat.service.spec.ts`: `/api/chat/stream` への fetch にヘッダ含まれるか検証
- `posts.service.spec.ts`: `searchSemantic` のランキング順序 / similarity クランプ / 0 ヒット動作

## Test plan

- [ ] backend: `npm test` で 80 件全 pass を確認（ローカル済）
- [ ] backend: `npm run lint` clean を確認（ローカル済）
- [ ] backend: `npx tsc --noEmit` clean（ローカル済）
- [ ] frontend: `npm run lint` + `npx tsc --noEmit` clean（ローカル済）
- [ ] staging: `INTERNAL_AI_TOKEN` を staging 環境変数に追加してから動作確認
- [ ] staging: 検索ページで AI意味検索トグル → 自然文クエリで結果と類似度 % が表示されるか
- [ ] staging: token を意図的に空にすると AI 機能がすべて停止（403/503）することを確認