### PR TITLE
fix(chat): AIチャットのエラーハンドリングと状態整合を改善

### DIFF
--- a/nokoroa-backend/src/chat/chat.controller.ts
+++ b/nokoroa-backend/src/chat/chat.controller.ts
@@ -3,7 +3,6 @@ import { Response } from 'express';
 import { ChatService } from './chat.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ChatRequestDto } from './dto/chat-request.dto';
-import { RelatedPostsRequestDto } from './dto/related-posts-request.dto';
 import { SuggestionsRequestDto } from './dto/suggestions-request.dto';
 
 @Controller('chat')
@@ -25,10 +24,5 @@ export class ChatController {
   ): Promise<{ suggestions: string[] }> {
     const suggestions = await this.chatService.getSuggestions(dto);
     return { suggestions };
-  }
-
-  @Post('related-posts')
-  async relatedPosts(@Body() dto: RelatedPostsRequestDto) {
-    return this.chatService.getRelatedPosts(dto);
   }
 }

--- a/nokoroa-backend/src/chat/chat.service.ts
+++ b/nokoroa-backend/src/chat/chat.service.ts
@@ -4,7 +4,6 @@ import { Response } from 'express';
 import { EmbeddingsService } from '../embeddings/embeddings.service';
 import { PostsService } from '../posts/posts.service';
 import { ChatRequestDto } from './dto/chat-request.dto';
-import { RelatedPostsRequestDto } from './dto/related-posts-request.dto';
 import { SuggestionsRequestDto } from './dto/suggestions-request.dto';
 
 @Injectable()
@@ -183,59 +182,5 @@ export class ChatService {
       if (post) found.push(post as unknown as Record<string, unknown>);
     }
     return found;
-  }
-
-  async getRelatedPosts(dto: RelatedPostsRequestDto) {
-    try {
-      const keywordsRes = await fetch(
-        `${this.aiServiceUrl}/api/chat/related-keywords`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            message: dto.message,
-            ai_response: dto.ai_response,
-          }),
-        },
-      );
-
-      if (!keywordsRes.ok) {
-        return { posts: [] };
-      }
-
-      const keywordsData = (await keywordsRes.json()) as {
-        keywords?: { location?: string };
-      };
-      const keywords = keywordsData.keywords;
-
-      if (!keywords) {
-        return { posts: [] };
-      }
-
-      const location = keywords.location ?? '';
-
-      const result = await this.postsService.search({
-        location,
-        limit: 3,
-        offset: 0,
-      });
-
-      if (result.posts.length > 0) {
-        return { posts: result.posts };
-      }
-
-      const fallbackResult = await this.postsService.search({
-        q: location,
-        limit: 3,
-        offset: 0,
-      });
-
-      return { posts: fallbackResult.posts };
-    } catch (error) {
-      this.logger.warn(
-        `Failed to get related posts: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-      return { posts: [] };
-    }
   }
 }

--- a/nokoroa-backend/src/chat/dto/related-posts-request.dto.ts
+++ b/nokoroa-backend/src/chat/dto/related-posts-request.dto.ts
@@ -1,9 +1,0 @@
-import { IsString } from 'class-validator';
-
-export class RelatedPostsRequestDto {
-  @IsString()
-  message: string;
-
-  @IsString()
-  ai_response: string;
-}

--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -304,7 +304,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
           }
 
           fullResponse += data;
-          charQueueRef.current.push(...data.split(''));
+          charQueueRef.current.push(...Array.from(data));
           startTyping();
         }
       }
@@ -458,7 +458,11 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const native = e.nativeEvent as KeyboardEvent;
+    if (native.isComposing || e.key === 'Process' || native.keyCode === 229) {
+      return;
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();

--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -103,11 +103,15 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
   ]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isResponding, setIsResponding] = useState(false);
   const [panelSize, setPanelSize] = useState<PanelSize>('medium');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const charQueueRef = useRef<string[]>([]);
   const typingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isRespondingRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -146,12 +150,21 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
       if (typingTimerRef.current) {
         clearInterval(typingTimerRef.current);
       }
+      abortControllerRef.current?.abort();
     };
   }, []);
+
+  useEffect(() => {
+    if (!isOpen && isRespondingRef.current) {
+      abortControllerRef.current?.abort();
+    }
+  }, [isOpen]);
 
   const handleToggleSize = () => {
     setPanelSize((prev) => {
@@ -163,7 +176,13 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
 
   const handleSend = async (messageText?: string) => {
     const textToSend = messageText || input.trim();
-    if (!textToSend || isLoading) return;
+    if (!textToSend || isRespondingRef.current) return;
+
+    isRespondingRef.current = true;
+    setIsResponding(true);
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
 
     const userMessage = textToSend;
     setInput('');
@@ -182,13 +201,23 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
 
     setTimeout(scrollToBottom, 100);
 
+    let responseStatus = 0;
+
     try {
       const history = messages.map((msg) => ({
         role: msg.role === 'assistant' ? 'model' : 'user',
         content: msg.content,
       }));
 
-      const token = localStorage.getItem('jwt');
+      let token: string | null = null;
+      try {
+        token = localStorage.getItem('jwt');
+      } catch (storageErr) {
+        console.warn(
+          '[ChatPanel] localStorage access failed, sending without token',
+          storageErr,
+        );
+      }
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
       };
@@ -203,10 +232,13 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
           message: userMessage,
           history,
         }),
+        signal: controller.signal,
       });
 
+      responseStatus = response.status;
+
       if (!response.ok) {
-        throw new Error('API request failed');
+        throw new Error(`HTTP_${response.status}`);
       }
 
       const reader = response.body?.getReader();
@@ -237,43 +269,46 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         buffer = lines.pop() || '';
 
         for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+
+          if (data.startsWith('{')) {
+            let parsed: unknown = null;
+            try {
+              parsed = JSON.parse(data);
+            } catch (parseErr) {
+              console.warn('[ChatPanel] invalid SSE JSON frame', parseErr);
               continue;
             }
-            if (data.startsWith('[ERROR]')) {
-              throw new Error(data);
-            }
-
-            if (data.startsWith('{')) {
-              try {
-                const parsed = JSON.parse(data);
-                if (parsed.type === 'related_posts' && parsed.posts) {
-                  receivedRelatedPosts = parsed.posts as PostData[];
-                  setMessages((prev) => {
-                    const lastMsg = prev[prev.length - 1];
-                    if (lastMsg?.role === 'assistant') {
-                      return [
-                        ...prev.slice(0, -1),
-                        { ...lastMsg, relatedPosts: parsed.posts },
-                      ];
-                    }
-                    return prev;
-                  });
-                  continue;
+            const event = parsed as { type?: string; posts?: PostData[] };
+            if (event.type === 'related_posts' && event.posts) {
+              receivedRelatedPosts = event.posts;
+              setMessages((prev) => {
+                const lastMsg = prev[prev.length - 1];
+                if (lastMsg?.role === 'assistant') {
+                  return [
+                    ...prev.slice(0, -1),
+                    { ...lastMsg, relatedPosts: event.posts },
+                  ];
                 }
-              } catch {}
+                return prev;
+              });
+            } else {
+              console.warn(
+                '[ChatPanel] unknown SSE event type, skipping',
+                event.type,
+              );
             }
-
-            fullResponse += data;
-            charQueueRef.current.push(...data.split(''));
-            startTyping();
+            continue;
           }
+
+          fullResponse += data;
+          charQueueRef.current.push(...data.split(''));
+          startTyping();
         }
       }
 
-      // Flush remaining characters in queue
       if (charQueueRef.current.length > 0) {
         const remaining = charQueueRef.current.join('');
         charQueueRef.current = [];
@@ -303,7 +338,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
         });
       }
 
-      if (fullResponse) {
+      if (fullResponse.trim()) {
         try {
           const suggestionsHeaders: Record<string, string> = {
             'Content-Type': 'application/json',
@@ -320,6 +355,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
                 message: userMessage,
                 ai_response: fullResponse,
               }),
+              signal: controller.signal,
             },
           );
           if (suggestionsRes.ok) {
@@ -327,36 +363,98 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
             if (suggestionsData?.suggestions?.length > 0) {
               setDynamicSuggestions(suggestionsData.suggestions);
             }
+          } else {
+            console.warn(
+              '[ChatPanel] suggestions request returned non-ok',
+              suggestionsRes.status,
+            );
           }
-        } catch {}
+        } catch (suggestionsErr) {
+          if ((suggestionsErr as Error)?.name !== 'AbortError') {
+            console.warn(
+              '[ChatPanel] suggestions fetch failed',
+              suggestionsErr,
+            );
+          }
+        }
       }
-    } catch {
-      stopTyping();
+    } catch (err) {
+      const remaining =
+        charQueueRef.current.length > 0 ? charQueueRef.current.join('') : '';
       charQueueRef.current = [];
+      stopTyping();
+
+      if ((err as Error)?.name === 'AbortError') {
+        if (remaining && mountedRef.current) {
+          setMessages((prev) => {
+            const lastIdx = prev.length - 1;
+            const lastMessage = prev[lastIdx];
+            if (
+              lastMessage?.role === 'assistant' &&
+              lastMessage.id !== 'initial'
+            ) {
+              return [
+                ...prev.slice(0, -1),
+                { ...lastMessage, content: lastMessage.content + remaining },
+              ];
+            }
+            return prev;
+          });
+        }
+        return;
+      }
+
+      console.error('[ChatPanel] handleSend failed', err);
+
+      const isNetworkError =
+        responseStatus === 0 &&
+        (err instanceof TypeError ||
+          (typeof navigator !== 'undefined' && navigator.onLine === false));
+
+      const errorContent = isNetworkError
+        ? 'ネットワーク接続を確認してください。'
+        : responseStatus === 401
+          ? 'ログインの有効期限が切れている可能性があります。再ログインしてお試しください。'
+          : responseStatus === 429
+            ? 'リクエストが集中しています。少し待ってから再度お試しください。'
+            : responseStatus >= 500
+              ? 'サーバーで問題が発生しました。時間を置いてお試しください。'
+              : '申し訳ありません。エラーが発生しました。もう一度お試しください。';
+
+      if (!mountedRef.current) return;
+
       setMessages((prev) => {
-        const lastMessage = prev[prev.length - 1];
-        if (lastMessage?.role === 'assistant' && lastMessage.content === '') {
+        const errorMessage: Message = {
+          role: 'assistant',
+          content: errorContent,
+          id: `error-${Date.now()}`,
+        };
+        const lastIdx = prev.length - 1;
+        const lastMessage = prev[lastIdx];
+        const isStreamingAssistant =
+          lastMessage?.role === 'assistant' && lastMessage.id !== 'initial';
+        if (isStreamingAssistant) {
+          const merged = lastMessage.content + remaining;
+          if (merged.length === 0) {
+            return [...prev.slice(0, -1), errorMessage];
+          }
           return [
             ...prev.slice(0, -1),
-            {
-              role: 'assistant',
-              content:
-                '申し訳ありません。エラーが発生しました。もう一度お試しください。',
-              id: `error-${Date.now()}`,
-            },
+            { ...lastMessage, content: merged },
+            errorMessage,
           ];
         }
-        return [
-          ...prev,
-          {
-            role: 'assistant',
-            content:
-              '申し訳ありません。エラーが発生しました。もう一度お試しください。',
-            id: `error-${Date.now()}`,
-          },
-        ];
+        return [...prev, errorMessage];
       });
-      setIsLoading(false);
+    } finally {
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null;
+      }
+      if (mountedRef.current) {
+        setIsLoading(false);
+        setIsResponding(false);
+      }
+      isRespondingRef.current = false;
     }
   };
 
@@ -375,7 +473,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
   const activeSuggestions =
     dynamicSuggestions.length > 0 ? dynamicSuggestions : SUGGESTIONS;
   const showSuggestions =
-    (messages.length <= 2 || dynamicSuggestions.length > 0) && !isLoading;
+    (messages.length <= 2 || dynamicSuggestions.length > 0) && !isResponding;
 
   return (
     <AnimatePresence>
@@ -640,7 +738,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
-                disabled={isLoading}
+                disabled={isResponding}
                 multiline
                 maxRows={3}
                 sx={{
@@ -652,7 +750,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
               <IconButton
                 color="primary"
                 onClick={() => handleSend()}
-                disabled={!input.trim() || isLoading}
+                disabled={!input.trim() || isResponding}
                 sx={{
                   bgcolor: 'primary.main',
                   color: 'primary.contrastText',


### PR DESCRIPTION
## Summary

AIチャット (Sora AI) のバグ修正と品質改善。フロントエンドの状態管理・エラーハンドリング・ストリーミング処理を整理し、バックエンドの未使用エンドポイントを削除。

## 修正内容

### フロントエンド (`ChatPanel.tsx`)
- **状態管理の分離**: \`isLoading\` (typing インジケータ用) と \`isResponding\` (入力ガード用) を分離。ストリーミング読み込み中に入力欄/送信ボタンが早期に有効化されていた問題を解消
- **連打レース防止**: \`isRespondingRef\` 同期ガード + \`AbortController\` を導入し、パネル閉鎖・アンマウント時にストリームを正しく中断
- **アンマウント後 setState 抑止**: \`mountedRef\` で finally / catch の setState を防御
- **ストリーミング中エラー時の状態整合**: 部分受信メッセージを保持してからエラー文を別バブルで追記。AbortError 時も partial を flush
- **エラーメッセージの状態コード別分岐**: 401 (再ログイン) / 429 (rate limit) / 5xx (サーバーエラー) / ネットワーク断 (\`navigator.onLine\` / \`TypeError\`) を区別
- **SSE フレーム解釈の構造化**: JSON parse 失敗時 \`console.warn\` + \`continue\`、不明 type も同様にスキップ (テキストへのフォールスルー禁止)
- **localStorage 保護**: Safari Private Mode 等で \`SecurityError\` が出てもゲスト送信にフォールバック
- **ログ追加**: 全 catch に \`[ChatPanel]\` プレフィックス付き \`console.error/warn\`
- **デッドコード削除**: backend が emit しない \`data: [ERROR]\` プレフィックス分岐を削除

### バックエンド
- 未使用エンドポイント \`POST /chat/related-posts\` (フロントから呼び出しなし) と関連 service メソッド・DTO を削除

## レビュー

- 専門家エージェントによる **5 ラウンド並列レビュー**を実施し、連続 2 ラウンド P0+P1=0 で収束

## Test plan

- [x] Backend Jest (chat + embeddings): 9 tests passed
- [x] Frontend ESLint: No warnings or errors
- [ ] ローカル動作確認: チャット送信 / 連打 / パネル開閉中の送信中断 / オフライン時の表示
- [ ] staging 動作確認