### PR TITLE
feat(chat): Stop ボタンと 401 時の再ログインリンクを追加

### DIFF
--- a/nokoroa-frontend/src/components/chat/ChatPanel.tsx
+++ b/nokoroa-frontend/src/components/chat/ChatPanel.tsx
@@ -4,9 +4,11 @@ import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import SendIcon from '@mui/icons-material/Send';
+import StopIcon from '@mui/icons-material/Stop';
 import {
   Avatar,
   Box,
+  Button,
   Chip,
   IconButton,
   Paper,
@@ -17,6 +19,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { AnimatePresence, motion } from 'framer-motion';
+import NextLink from 'next/link';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { PostData } from '@/types/post';
@@ -28,6 +31,7 @@ interface Message {
   content: string;
   id: string;
   relatedPosts?: PostData[];
+  needsLogin?: boolean;
 }
 
 interface ChatPanelProps {
@@ -173,6 +177,10 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
       return 'small';
     });
   };
+
+  const handleStop = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
 
   const handleSend = async (messageText?: string) => {
     const textToSend = messageText || input.trim();
@@ -428,6 +436,7 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
           role: 'assistant',
           content: errorContent,
           id: `error-${Date.now()}`,
+          needsLogin: responseStatus === 401,
         };
         const lastIdx = prev.length - 1;
         const lastMessage = prev[lastIdx];
@@ -628,6 +637,18 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
                       >
                         {message.content}
                       </Typography>
+                      {message.needsLogin && (
+                        <Button
+                          component={NextLink}
+                          href="/login"
+                          size="small"
+                          variant="contained"
+                          color="primary"
+                          sx={{ mt: 1, textTransform: 'none' }}
+                        >
+                          ログインページへ
+                        </Button>
+                      )}
                     </Paper>
                     {message.relatedPosts &&
                       message.relatedPosts.length > 0 && (
@@ -751,24 +772,44 @@ export default function ChatPanel({ isOpen }: ChatPanelProps) {
                   },
                 }}
               />
-              <IconButton
-                color="primary"
-                onClick={() => handleSend()}
-                disabled={!input.trim() || isResponding}
-                sx={{
-                  bgcolor: 'primary.main',
-                  color: 'primary.contrastText',
-                  '&:hover': {
-                    bgcolor: 'primary.dark',
-                  },
-                  '&:disabled': {
-                    bgcolor: 'action.disabledBackground',
-                    color: 'action.disabled',
-                  },
-                }}
-              >
-                <SendIcon fontSize="small" />
-              </IconButton>
+              {isResponding ? (
+                <Tooltip title="停止">
+                  <IconButton
+                    color="primary"
+                    onClick={handleStop}
+                    aria-label="応答を停止"
+                    sx={{
+                      bgcolor: 'primary.main',
+                      color: 'primary.contrastText',
+                      '&:hover': {
+                        bgcolor: 'primary.dark',
+                      },
+                    }}
+                  >
+                    <StopIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              ) : (
+                <IconButton
+                  color="primary"
+                  onClick={() => handleSend()}
+                  disabled={!input.trim()}
+                  aria-label="送信"
+                  sx={{
+                    bgcolor: 'primary.main',
+                    color: 'primary.contrastText',
+                    '&:hover': {
+                      bgcolor: 'primary.dark',
+                    },
+                    '&:disabled': {
+                      bgcolor: 'action.disabledBackground',
+                      color: 'action.disabled',
+                    },
+                  }}
+                >
+                  <SendIcon fontSize="small" />
+                </IconButton>
+              )}
             </Box>
           </Box>
         </MotionPaper>


### PR DESCRIPTION
## Summary

AIチャット (Sora AI) に **Stop ボタン** と **再ログインリンク** を追加。

## 変更内容

### 1. Stop ボタン
- ストリーミング中 (`isResponding=true`) に送信ボタンを `StopIcon` に切替
- クリックで `abortControllerRef.current.abort()` を呼出し、AI 応答を即時中断
- 既存の AbortError 経路 (catch ブロックで `stopTyping()` + `charQueueRef` クリア + 部分受信のマージ) と `finally` のクリーンアップに乗るため、追加の状態整合は不要

### 2. 再ログインリンク
- `Message` 型に `needsLogin?: boolean` を追加
- 401 エラー時のエラーメッセージに `needsLogin: true` を付与
- バブル内に MUI Button (`component={NextLink} href=\"/login\"`) で「ログインページへ」を表示
- 401 以外のエラーには表示されない

## 依存

このPRは #28 (fix/ai-chat-improvements) をベースにしています。#28 がマージされた後、自動的に base が main に切り替わります。

## レビュー収束

並列レビュー2ラウンドを実施し、**連続 P0+P1=0 で収束**確認。

## Test plan

- [x] ESLint: No warnings or errors
- [ ] ストリーミング中に Stop ボタンを押下 → 即停止 + 部分受信メッセージが残ること
- [ ] 401 エラー時に「ログインページへ」ボタンが表示され、/login へ遷移すること
- [ ] 401 以外のエラー (429/5xx/network) では「ログインページへ」ボタンが表示されないこと
- [ ] 日本語 IME 入力中の Enter で誤送信されないこと (前 PR の動作維持)